### PR TITLE
Refactorización, parte 1

### DIFF
--- a/MejorAppTG1/App.xaml
+++ b/MejorAppTG1/App.xaml
@@ -2,13 +2,15 @@
 <Application xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:local="clr-namespace:MejorAppTG1"
+             xmlns:converters="clr-namespace:MejorAppTG1.Utils.Converters"
              x:Class="MejorAppTG1.App">
     <Application.Resources>
         <ResourceDictionary>
-            <local:ContenidoToBackgroundColorConverter x:Key="ContenidoToBackgroundColorConverter" />
-            <local:ContenidoToFontColorConverter x:Key="ContenidoToFontColorConverter" />
-            <local:TranslationKeyConverter x:Key="TranslationKeyConverter" />
-            <local:StringToMediaSourceConverter x:Key="StringToMediaSourceConverter" />
+            <converters:ContenidoToBackgroundColorConverter x:Key="ContenidoToBackgroundColorConverter" />
+            <converters:ContenidoToFontColorConverter x:Key="ContenidoToFontColorConverter" />
+            <converters:TranslationKeyConverter x:Key="TranslationKeyConverter" />
+            <converters:StringToMediaSourceConverter x:Key="StringToMediaSourceConverter" />
+            <converters:NullToDefaultImageConverter x:Key="NullToDefaultImageConverter" />
             <Color x:Key="PrimaryColor">#92ed8b</Color>
             <Color x:Key="SecondaryColor1">#74c475</Color>
             <Color x:Key="SecondaryColor2">#b5f3a5</Color>

--- a/MejorAppTG1/AppShell.xaml
+++ b/MejorAppTG1/AppShell.xaml
@@ -15,7 +15,7 @@
                          ContentTemplate="{DataTemplate local:MainPage}" Route="MainPage" Icon="main_menu_icon.png"
                          SemanticProperties.Description="{x:Static strings:Strings.str_SemanticProperties_Shell_MainMenu}"/>
             <ShellContent Title="{x:Static strings:Strings.str_Shell_MyProfileTab}" Shell.UnselectedColor="Green"
-                         ContentTemplate="{DataTemplate local:ResultHistoryPage}" Route="ResultHistoryPage" Icon="profile_icon.png" 
+                         ContentTemplate="{DataTemplate local:MyProfilePage}" Route="MyProfilePage" Icon="profile_icon.png" 
                          SemanticProperties.Description="{x:Static strings:Strings.str_SemanticProperties_Shell_ProfileTab}"/>
 
         </Tab>

--- a/MejorAppTG1/AppShell.xaml.cs
+++ b/MejorAppTG1/AppShell.xaml.cs
@@ -443,7 +443,7 @@ namespace MejorAppTG1
                     if (currentPage is MainPage mainPage) {
                         mainPage.LoadUserName();
                     }
-                    else if (currentPage is ResultHistoryPage resultHistoryPage) {
+                    else if (currentPage is MyProfilePage resultHistoryPage) {
                         resultHistoryPage.UpdateUserLabels();
                     }
 
@@ -467,8 +467,8 @@ namespace MejorAppTG1
                     await App.Database.DeleteUsuarioAsync(App.CurrentUser);
                     App.CurrentUser = null;
                     Preferences.Clear();
-                    ResultHistoryPage.ResultIndex = 0;
-                    ResultHistoryPage.CurrentPage = 1;
+                    MyProfilePage.ResultIndex = 0;
+                    MyProfilePage.CurrentPage = 1;
                     Application.Current.MainPage = new NavigationPage(new LoginPage());
                 }
             } finally {
@@ -482,8 +482,8 @@ namespace MejorAppTG1
             App.ButtonPressed = true;
             try {
                 Preferences.Clear();
-                ResultHistoryPage.ResultIndex = 0;
-                ResultHistoryPage.CurrentPage = 1;
+                MyProfilePage.ResultIndex = 0;
+                MyProfilePage.CurrentPage = 1;
                 App.CurrentUser = null;
                 Application.Current.MainPage = new NavigationPage(new LoginPage());
             } finally {

--- a/MejorAppTG1/MejorAppTG1.csproj
+++ b/MejorAppTG1/MejorAppTG1.csproj
@@ -129,6 +129,9 @@
 	    <AutoGen>True</AutoGen>
 	    <DependentUpon>Strings.resx</DependentUpon>
 	  </Compile>
+	  <Compile Update="Views\MyProfilePage.xaml.cs">
+	    <DependentUpon>MyProfilePage.xaml</DependentUpon>
+	  </Compile>
 	  <Compile Update="Views\ResultsPage.xaml.cs">
 	    <DependentUpon>ResultsPage.xaml</DependentUpon>
 	  </Compile>
@@ -151,7 +154,10 @@
 	  <MauiXaml Update="Views\ResultsPage.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>
-	  <MauiXaml Update="Views\ResultHistoryPage.xaml">
+	  <MauiXaml Update="Views\MyProfilePage.xaml">
+	    <Generator>MSBuild:Compile</Generator>
+	  </MauiXaml>
+	  <MauiXaml Update="Views\UserSelectPopup.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>
 	</ItemGroup>

--- a/MejorAppTG1/Resources/Localization/Strings.Designer.cs
+++ b/MejorAppTG1/Resources/Localization/Strings.Designer.cs
@@ -112,7 +112,7 @@ namespace MejorAppTG1.Resources.Localization {
         /// <summary>
         ///   Busca una cadena traducida similar a Slowly read the following metaphor:
         ///&quot;Imagine you&apos;re at sea, a seemingly calm place, and suddenly, a massive wave appears. As it approaches you feel afraid and you instinctively run away from it, but by getting away, the wave becomes stronger and more frightening and seemingly continues to chase you.
-        ///The farther you run away from the wave, the bigger it becomes, and the farther you run away, the stronger it gets. However, if you don&apos;t avoid the wave, the crash will be strong at first, but you will eventual [resto de la cadena truncado]&quot;;.
+        ///The farther you run away from the wave, the bigger it becomes, and the farther you run away, the stronger it gets. However, if you don&apos;t avoid the wave, the crash will be strong at first, but you will eventually [resto de la cadena truncado]&quot;;.
         /// </summary>
         internal static string str_AnxietyAdvice11_Content {
             get {
@@ -246,7 +246,7 @@ namespace MejorAppTG1.Resources.Localization {
         ///● When it happened: Monday, considering that I have 3 exams.
         ///● What I&apos;m feeling: Anxiety, trouble breathing...
         ///● Now see the situation from the outside (like in a third-person video game) and explain it.
-        ///● What I can do to cope with the situation: Focus on one exam and when you finish with another one...; help yourself  [resto de la cadena truncado]&quot;;.
+        ///● What I can do to cope with the situation: Focus on one exam and when you finish with another one...; help yourself with [resto de la cadena truncado]&quot;;.
         /// </summary>
         internal static string str_AnxietyAdvice18_Content {
             get {
@@ -449,7 +449,7 @@ namespace MejorAppTG1.Resources.Localization {
         
         /// <summary>
         ///   Busca una cadena traducida similar a Slowly read this paragraph when you have an anxiety attack: &quot;All these symptoms you are currently feeling, even if they are unpleasant, ARE NOT DANGEROUS, YOU ARE NOT GOING TO DIE, NOR ARE YOU GOING TO LOSE CONTROL OF YOUR BREATHING. This crisis you are feeling has a beginning, a peak and an end. This means that whatever you do, it will end, even if you do nothing. So avoid trying to control or fight it, that will make it worse.
-        ///Instead, listen to your body and try to name whatever you are feeling right no [resto de la cadena truncado]&quot;;.
+        ///Instead, listen to your body and try to name whatever you are feeling right now [resto de la cadena truncado]&quot;;.
         /// </summary>
         internal static string str_AnxietyAdvice7_Content {
             get {
@@ -2677,7 +2677,7 @@ namespace MejorAppTG1.Resources.Localization {
         /// <summary>
         ///   Busca una cadena traducida similar a All the tests herein presented are adapted as closely as possible from the following studies:
         ///• &quot;Propiedades psicométricas de un cuestionario para la evaluación de la ansiedad ante los exámenes en adolescentes&quot;: Rosa Torrano-Martínez, Juan Manuel Ortigosa-Quiles, Antonio Riquelme-Marín and José Antonio López-Pina (University of Murcia).
-        ///• &quot;Comprendiendo el papel de la práctica física y el género en los trastornos alimentarios en estudiantes adolescentes españoles&quot;: Gema Sanchis-Soler, Irene León-Calero, S [resto de la cadena truncado]&quot;;.
+        ///• &quot;Comprendiendo el papel de la práctica física y el género en los trastornos alimentarios en estudiantes adolescentes españoles&quot;: Gema Sanchis-Soler, Irene León-Calero, Ser [resto de la cadena truncado]&quot;;.
         /// </summary>
         internal static string str_Shell_AboutPage_ScientificBase_Msg {
             get {
@@ -2745,7 +2745,7 @@ namespace MejorAppTG1.Resources.Localization {
         ///• Complete anxiety test: consists of 48 questions and can be completed in approximately 6 minutes.
         ///• Eating disorders test: consists of 26 questions and can be completed in approximately 3 minutes.
         ///
-        ///In each test, each question will be presented individually. Each question consists of 5 possible answers, and you must select one to advance to the n [resto de la cadena truncado]&quot;;.
+        ///In each test, each question will be presented individually. Each question consists of 5 possible answers, and you must select one to advance to the next q [resto de la cadena truncado]&quot;;.
         /// </summary>
         internal static string str_Shell_HelpPage_MainMenu_Msg {
             get {
@@ -2755,7 +2755,7 @@ namespace MejorAppTG1.Resources.Localization {
         
         /// <summary>
         ///   Busca una cadena traducida similar a In the &quot;My profile&quot; tab, you can see the details of the profile currently logged in to the application (name, age and gender). Remember that you can change these details or even create a new user from the menu in the top right corner. You can also change your profile picture by clicking on the picture itself.
-        ///Just below, you will see a list of the tests you have completed with this user in chronological order, with the most recent one first. If you click on any of them, the tips associated with your answer [resto de la cadena truncado]&quot;;.
+        ///Just below, you will see a list of the tests you have completed with this user in chronological order, with the most recent one first. If you click on any of them, the tips associated with your answers [resto de la cadena truncado]&quot;;.
         /// </summary>
         internal static string str_Shell_HelpPage_MyProfile_Msg {
             get {
@@ -2785,7 +2785,7 @@ namespace MejorAppTG1.Resources.Localization {
         ///   Busca una cadena traducida similar a In the top navigation bar, you can change between the two main tabs that make up the app: the main menu and your profile. Below you&apos;ll find more details about each of these tabs.
         ///• By clicking on (i), you can see information about this project, the involved developers and the studies that endorse this app.
         ///• By clicking on (?), you can access the app&apos;s help, as you will have already been able to see for yourself.
-        ///• Finally, by clicking on the kebab menu (the three little dots in the top right corner), yo [resto de la cadena truncado]&quot;;.
+        ///• Finally, by clicking on the kebab menu (the three little dots in the top right corner), you w [resto de la cadena truncado]&quot;;.
         /// </summary>
         internal static string str_Shell_HelpPage_TopBar_Msg {
             get {
@@ -3016,6 +3016,15 @@ namespace MejorAppTG1.Resources.Localization {
         internal static string str_TestPage_QuestionCount {
             get {
                 return ResourceManager.GetString("str_TestPage_QuestionCount", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Busca una cadena traducida similar a Please select an user..
+        /// </summary>
+        internal static string str_UserSelectPopup_ChooseUserToast {
+            get {
+                return ResourceManager.GetString("str_UserSelectPopup_ChooseUserToast", resourceCulture);
             }
         }
     }

--- a/MejorAppTG1/Resources/Localization/Strings.es.resx
+++ b/MejorAppTG1/Resources/Localization/Strings.es.resx
@@ -1136,4 +1136,7 @@ audiorelax.mp3</value>
   <data name="str_SemanticProperties_MainPage_Welcome" xml:space="preserve">
     <value>Te encuentras en el menú principal de la aplicación. Más abajo encontrarás los tres tipos de tests a realizar: test rápido de ansiedad (duración estimada: 2 minutos), test completo de ansiedad (duración estimada: 6 minutos), test para trastornos de la conducta alimentaria (duración estimada: 3 minutos).</value>
   </data>
+  <data name="str_UserSelectPopup_ChooseUserToast" xml:space="preserve">
+    <value>Por favor, selecciona un usuario.</value>
+  </data>
 </root>

--- a/MejorAppTG1/Resources/Localization/Strings.fr.resx
+++ b/MejorAppTG1/Resources/Localization/Strings.fr.resx
@@ -1136,4 +1136,7 @@ Cela ne prendra qu'un instant !</value>
   <data name="str_SemanticProperties_MainPage_Welcome" xml:space="preserve">
     <value>Bienvenue dans le menu principal de l'application. Vous trouverez ci-dessous les trois types de tests à effectuer : test d'anxiété rapide (durée estimée : 2 minutes), test d'anxiété complet (durée estimée : 6 minutes), test pour les troubles de la conduite alimentaire (durée estimée : 3 minutes).</value>
   </data>
+  <data name="str_UserSelectPopup_ChooseUserToast" xml:space="preserve">
+    <value>Veuillez sélectionner un utilisateur.</value>
+  </data>
 </root>

--- a/MejorAppTG1/Resources/Localization/Strings.resx
+++ b/MejorAppTG1/Resources/Localization/Strings.resx
@@ -1137,4 +1137,7 @@ It will only take a moment!</value>
   <data name="str_SemanticProperties_MainPage_Welcome" xml:space="preserve">
     <value>You are in the app's main menu. Below you will find the three types of tests to take: quick anxiety test (estimated time: 2 minutes), complete anxiety test (estimated time: 6 minutes), eating disorders test (estimated time: 3 minutes).</value>
   </data>
+  <data name="str_UserSelectPopup_ChooseUserToast" xml:space="preserve">
+    <value>Please select an user.</value>
+  </data>
 </root>

--- a/MejorAppTG1/Utils/Converters/ContenidoToBackgroundColorConverter.cs
+++ b/MejorAppTG1/Utils/Converters/ContenidoToBackgroundColorConverter.cs
@@ -1,0 +1,23 @@
+﻿using System.Globalization;
+
+namespace MejorAppTG1.Utils.Converters
+{
+    public class ContenidoToBackgroundColorConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            // Si el contenido es nulo o vacío, hacer el fondo transparente.
+            if (value == null || string.IsNullOrEmpty(value.ToString())) {
+                return Colors.Transparent;
+            }
+
+            // Si tiene contenido, establecer el color de fondo predeterminado
+            return (Color)Application.Current.Resources["SecondaryColor1"];
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return null;
+        }
+    }
+}

--- a/MejorAppTG1/Utils/Converters/ContenidoToFontColorConverter.cs
+++ b/MejorAppTG1/Utils/Converters/ContenidoToFontColorConverter.cs
@@ -1,0 +1,21 @@
+﻿using System.Globalization;
+
+namespace MejorAppTG1.Utils.Converters
+{
+    public class ContenidoToFontColorConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value == null || string.IsNullOrEmpty(value.ToString())) {
+                return (Color)Application.Current.Resources["FontColor1"];
+            }
+
+            return (Color)Application.Current.Resources["FontColor2"];
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return null;
+        }
+    }
+}

--- a/MejorAppTG1/Utils/Converters/NullToDefaultImageConverter.cs
+++ b/MejorAppTG1/Utils/Converters/NullToDefaultImageConverter.cs
@@ -1,0 +1,18 @@
+﻿using System.Globalization;
+
+namespace MejorAppTG1.Utils.Converters
+{
+    public class NullToDefaultImageConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            string? imagePath = value as string;
+            return string.IsNullOrEmpty(imagePath) ? "profile_icon.png" : imagePath;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/MejorAppTG1/Utils/Converters/StringToMediaSourceConverter.cs
+++ b/MejorAppTG1/Utils/Converters/StringToMediaSourceConverter.cs
@@ -1,0 +1,22 @@
+﻿using CommunityToolkit.Maui.Views;
+using System.Globalization;
+
+namespace MejorAppTG1.Utils.Converters
+{
+    public class StringToMediaSourceConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is string uriString && !string.IsNullOrEmpty(uriString)) {
+                // Convertir la cadena en un MediaSource
+                return MediaSource.FromResource(uriString);
+            }
+            return null;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return null;
+        }
+    }
+}

--- a/MejorAppTG1/Utils/Converters/TranslationKeyConverter.cs
+++ b/MejorAppTG1/Utils/Converters/TranslationKeyConverter.cs
@@ -1,0 +1,23 @@
+﻿using MejorAppTG1.Resources.Localization;
+using System.Globalization;
+
+namespace MejorAppTG1.Utils.Converters
+{
+    public class TranslationKeyConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value == null) return null;
+
+            // Se espera que `value` sea una clave de recurso como "str_AnsiedadRapido"
+            string key = value.ToString();
+            string translation = Strings.ResourceManager.GetString(key, CultureInfo.CurrentUICulture);
+            return translation ?? key;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return null;
+        }
+    }
+}

--- a/MejorAppTG1/Views/LoginPage.xaml.cs
+++ b/MejorAppTG1/Views/LoginPage.xaml.cs
@@ -1,6 +1,8 @@
 using CommunityToolkit.Maui.Views;
 using MejorAppTG1.Models;
 using MejorAppTG1.Resources.Localization;
+using MejorAppTG1.Utils.Converters;
+using MejorAppTG1.Views;
 using Microsoft.Maui.Controls.Shapes;
 using Microsoft.Maui.Storage;
 using System.Globalization;
@@ -157,214 +159,15 @@ internal class SignUpPopup : Popup {
     }
 }
 
-internal class UsersPopup : Popup {
-    public UsersPopup(List<User> usuarios) {
-        var layout = new Grid {
-            HeightRequest = 400,
-            WidthRequest = 350,
-            BackgroundColor = (Color)Application.Current.Resources["SecondaryColor3"],
-            RowDefinitions =
-            {
-                new RowDefinition { Height = GridLength.Auto }, // Título
-                new RowDefinition { Height = GridLength.Star }  // Usuarios
-            }
-        };
-
-        var image = new Image {
-            Source = "fondo_provisional1.jpeg",
-            Aspect = Aspect.AspectFill
-        };
-
-
-        var titulo = new Label {
-            Text = Strings.str_LoginPage_LblSelectUser,
-            FontSize = 22,
-            Margin = new Thickness(0, 20, 0, 5),
-            TextColor = (Color)Application.Current.Resources["FontColor1"],
-            HorizontalOptions = LayoutOptions.Center,
-            FontAttributes = FontAttributes.Bold
-        };
-        SemanticProperties.SetHeadingLevel(titulo, SemanticHeadingLevel.Level1);
-        SemanticProperties.SetDescription(titulo, Strings.str_SemanticProperties_LoginPage_UsersPopup_Title);
-        layout.Add(image);
-        layout.Add(titulo);
-        Grid.SetRow(titulo, 0);
-        Grid.SetRowSpan(image, 2);
-
-        var collectionView = new CollectionView {
-            VerticalScrollBarVisibility = ScrollBarVisibility.Always,
-            SelectionMode = SelectionMode.Single,
-            ItemsSource = usuarios,
-            ItemTemplate = new DataTemplate(() => {
-                var frame = new Frame {
-                    BorderColor = (Color)Application.Current.Resources["ButtonColor2"],
-                    CornerRadius = 10,
-                    Margin = 15,
-                    Padding = 10,
-                    BackgroundColor = (Color)Application.Current.Resources["SecondaryColor4"]
-                };
-
-                var grid = new Grid {
-                    ColumnDefinitions =
-                    {
-                        new ColumnDefinition { Width = GridLength.Star }, // Texto
-                        new ColumnDefinition { Width = GridLength.Auto }  // Icono
-                    },
-                    Padding = new Thickness(10),
-                    VerticalOptions = LayoutOptions.Center
-                };
-
-                var verticalLayout = new VerticalStackLayout {
-                    Spacing = 2,
-                    VerticalOptions = LayoutOptions.Center
-                };
-
-                var nombreLabel = new Label {
-                    FontSize = 20,
-                    TextColor = (Color)Application.Current.Resources["FontColor4"],
-                    FontAttributes = FontAttributes.Bold
-                };
-                nombreLabel.SetBinding(Label.TextProperty, "Nombre");
-                SemanticProperties.SetDescription(nombreLabel, Strings.str_SemanticProperties_LoginPage_UsersPopup_Name);
-
-                var edadLabel = new Label {
-                    FontSize = 15,
-                    TextColor = (Color)Application.Current.Resources["FontColor5"],
-                    FontAttributes = FontAttributes.Bold
-                };
-                edadLabel.SetBinding(Label.TextProperty, "Edad");
-                edadLabel.BindingContextChanged += (sender, e) =>
-                {
-                    var user = (User)((Label)sender).BindingContext;
-                    if (user != null) {
-                        int edad = user.Edad;
-
-                        // Traducir el formato de la edad según el idioma actual
-                        string translatedAgeFormat = Strings.str_ResultHistoryPage_LblAge_Dyn;
-
-                        // Formatear la edad con la cadena traducida
-                        string translatedAge = string.Format(translatedAgeFormat, edad);
-
-                        // Asignar el texto traducido al Label
-                        edadLabel.Text = translatedAge;
-                    }
-                };
-                SemanticProperties.SetDescription(edadLabel, Strings.str_SemanticProperties_LoginPage_UsersPopup_Age);
-
-                var generoLabel = new Label {
-                    FontSize = 12,
-                    TextColor = (Color)Application.Current.Resources["FontColor6"],
-                    FontAttributes = FontAttributes.Bold
-                };
-
-                generoLabel.SetBinding(Label.TextProperty, "Genero");
-                generoLabel.BindingContextChanged += (sender, e) =>
-                {
-                    var user = (User)((Label)sender).BindingContext;
-                    if (user != null) {
-                        // Traducir el género según el idioma actual
-                        string translatedGender = user.Genero switch {
-                            "str_Genders_Man" => Strings.str_Genders_Man,
-                            "str_Genders_Woman" => Strings.str_Genders_Woman,
-                            "str_Genders_NB" => Strings.str_Genders_NB
-                        };
-
-                        // Asignar el texto traducido al Label
-                        generoLabel.Text = translatedGender;
-                    }
-                };
-                SemanticProperties.SetDescription(generoLabel, Strings.str_SemanticProperties_LoginPage_UsersPopup_Gender);
-
-                verticalLayout.Add(nombreLabel);
-                verticalLayout.Add(edadLabel);
-                verticalLayout.Add(generoLabel);
-
-                // Icono a la derecha
-                var icono = new Image {
-                    Source = "profile_icon.png",
-                    BackgroundColor = Colors.Transparent,
-                    HeightRequest = 60,
-                    WidthRequest = 60,
-                    VerticalOptions = LayoutOptions.Center,
-                    HorizontalOptions = LayoutOptions.Center,
-                    Aspect = Aspect.AspectFill,
-                    Clip = new EllipseGeometry {
-                        Center = new Point(30, 30),
-                        RadiusX = 30,
-                        RadiusY = 30
-                    }
-                };
-
-                icono.SetBinding(Image.SourceProperty, new Binding("Imagen", converter: new NullToDefaultImageConverter()));
-                SemanticProperties.SetDescription(icono, Strings.str_SemanticProperties_LoginPage_UsersPopup_Image);
-
-                grid.Add(verticalLayout, 0, 0);
-                grid.Add(icono, 1, 0);
-
-                frame.Content = grid;
-
-                frame.BindingContextChanged += (sender, e) =>
-                {
-                    var currentFrame = (Frame)sender;
-                    if (currentFrame.BindingContext is User user) {
-                        // Formatear la edad con la cadena traducida
-                        string translatedAgeFormat = Strings.str_ResultHistoryPage_LblAge_Dyn;
-                        string translatedAge = string.Format(translatedAgeFormat, user.Edad);
-
-                        // Crear la descripción combinada
-                        string semanticDescription = string.Format(Strings.str_SemanticProperties_LoginPage_UsersPopup_SelectedUser, user.Nombre, translatedAge, Strings.ResourceManager.GetString(user.Genero, CultureInfo.CurrentUICulture));
-
-                        // Asignar la descripción al SemanticProperties.Description del Frame
-                        SemanticProperties.SetDescription(currentFrame, semanticDescription);
-                    }
-                };
-
-                var tapGesture = new TapGestureRecognizer();
-                tapGesture.Tapped += (s, e) => {
-                    App.AnimateFrameInOut(frame);
-                    if (frame.BindingContext is User usuarioSeleccionado) {
-                        Close(usuarioSeleccionado);
-                    }
-                };
-                frame.GestureRecognizers.Add(tapGesture);
-
-                frame.SetBinding(BindingContextProperty, new Binding("."));
-
-                return frame;
-            }),
-            BackgroundColor = Colors.Transparent,
-            VerticalOptions = LayoutOptions.FillAndExpand
-        };
-
-        //SemanticProperties.SetDescription(collectionView, Strings.str_SemanticProperties_LoginPage_UsersPopup_List);
-        collectionView.SelectionChanged += (sender, args) => {
-            if (args.CurrentSelection.FirstOrDefault() is User usuarioSeleccionado) {
-                SemanticScreenReader.Announce(string.Format(Strings.str_SemanticProperties_LoginPage_UsersPopup_SelectedUser2, usuarioSeleccionado.Nombre));
-                Close(usuarioSeleccionado);
-            }
-        };
-
-        layout.Add(collectionView);
-        Grid.SetRow(collectionView, 1);
-        Content = layout;
-    }
-}
-
 public partial class LoginPage : ContentPage {
 
     public LoginPage() {
         InitializeComponent();
         Shell.SetNavBarIsVisible(this, false);
 
-
         if (DeviceInfo.Current.Platform != DevicePlatform.iOS) {
             this.SemanticOrderView.ViewOrder = new List<View> { LblDos, ImageUno, LblTitulo, LblUno };
         }
-
-
-        //Preferences
-        //LoadSavedName();
-
     }
 
     private async void CrearUsuario_Clicked(object sender, EventArgs e) {
@@ -378,20 +181,6 @@ public partial class LoginPage : ContentPage {
                 string newName = inputs.Item1;
                 int newAge = inputs.Item2;
                 string newGender = inputs.Item3;
-
-                /*
-                //guardar preferences del name
-                string name = nickUsuario.Text;
-                Preferences.Set(NameKey, name);
-
-                //guardar preferences de la edad
-                string age = edadUsuario.Text;
-                Preferences.Set(AgeKey, age);
-
-                //guardar preferences del genero
-                string gender = generoUsuario.SelectedItem.ToString();
-                Preferences.Set(GenderKey, gender);
-                */
 
                 User newUser = new User {
                     Nombre = newName,
@@ -414,29 +203,6 @@ public partial class LoginPage : ContentPage {
         }
     }
 
-    // Verificar si está almacenado en las preferencias
-    /*private void LoadSavedName() {
-        if (Preferences.ContainsKey(NameKey)) {
-            string savedName = Preferences.Get(NameKey, string.Empty);
-            nickUsuario.Text = savedName;
-        }
-
-        if (Preferences.ContainsKey(AgeKey)) {
-            string savedAge = Preferences.Get(AgeKey, string.Empty);
-            edadUsuario.Text = savedAge;
-        }
-
-        if (Preferences.ContainsKey(GenderKey)) {
-            string savedGenero = Preferences.Get(GenderKey, string.Empty);
-
-            // Actualizar el Picker para reflejar la selección guardada
-            int savedIndex = generoUsuario.Items.IndexOf(savedGenero);
-            if (savedIndex != -1) {
-                generoUsuario.SelectedIndex = savedIndex;
-            }
-        }
-    }*/
-
     private async void BtnLogIn_Clicked(object sender, EventArgs e) {
         if (App.ButtonPressed) return;
         App.ButtonPressed = true;
@@ -448,7 +214,8 @@ public partial class LoginPage : ContentPage {
                 SemanticScreenReader.Announce(Strings.str_SemanticProperties_LoginPage_BtnLogIn_NoUsers);
             }
             else {
-                var popup = new UsersPopup(activeUsers);
+                var popup = new UserSelectPopup(activeUsers);
+                App.ButtonPressed = false;
                 var selectedUser = await Application.Current.MainPage.ShowPopupAsync(popup) as User;
 
                 if (selectedUser != null) {
@@ -464,16 +231,5 @@ public partial class LoginPage : ContentPage {
         } finally {
             App.ButtonPressed = false;
         }
-    }
-}
-
-public class NullToDefaultImageConverter : IValueConverter {
-    public object Convert(object value, Type targetType, object parameter, CultureInfo culture) {
-        string imagePath = value as string;
-        return string.IsNullOrEmpty(imagePath) ? "profile_icon.png" : imagePath;
-    }
-
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) {
-        throw new NotImplementedException();
     }
 }

--- a/MejorAppTG1/Views/MyProfilePage.xaml
+++ b/MejorAppTG1/Views/MyProfilePage.xaml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="MejorAppTG1.ResultHistoryPage"
+             x:Class="MejorAppTG1.MyProfilePage"
              xmlns:strings="clr-namespace:MejorAppTG1.Resources.Localization"
              Shell.BackgroundColor="{StaticResource SecondaryColor1}" Title="MejorAppT" Appearing="OnPageAppearing">
     <ContentPage.Background>

--- a/MejorAppTG1/Views/MyProfilePage.xaml.cs
+++ b/MejorAppTG1/Views/MyProfilePage.xaml.cs
@@ -12,28 +12,7 @@ using System.Numerics;
 
 namespace MejorAppTG1;
 
-public class TranslationKeyConverter : IValueConverter
-{
-    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
-    {
-        if (value == null) return null;
-
-        // Se espera que `value` sea una clave de recurso como "str_AnsiedadRapido"
-        string key = value.ToString();
-
-        // Buscar la traducción en el archivo de recursos
-        string translation = Strings.ResourceManager.GetString(key, CultureInfo.CurrentUICulture);
-
-        // Si no se encuentra la clave, devolver la clave como fallback
-        return translation ?? key;
-    }
-
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
-    {
-        return null;
-    }
-}
-public partial class ResultHistoryPage : ContentPage
+public partial class MyProfilePage : ContentPage
 {
     private static int resultIndex = 0;
     private static int currentPage = 1;
@@ -43,7 +22,7 @@ public partial class ResultHistoryPage : ContentPage
     public static int ResultIndex { get => resultIndex; set => resultIndex = value; }
     public static int CurrentPage { get => currentPage; set => currentPage = value; }
 
-    public ResultHistoryPage()
+    public MyProfilePage()
     {
         InitializeComponent();
     }

--- a/MejorAppTG1/Views/ResultsPage.xaml.cs
+++ b/MejorAppTG1/Views/ResultsPage.xaml.cs
@@ -12,60 +12,6 @@ namespace MejorAppTG1;
 
 using Microsoft.Maui.Controls;
 
-public class StringToMediaSourceConverter : IValueConverter
-{
-    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
-    {
-        if (value is string uriString && !string.IsNullOrEmpty(uriString)) {
-            // Convertir la cadena en un MediaSource
-            return MediaSource.FromResource(uriString);
-        }
-        return null;
-    }
-
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
-    {
-        return null;
-    }
-}
-
-public class ContenidoToBackgroundColorConverter : IValueConverter
-{
-    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
-    {
-        // Si el contenido es nulo o vacío, hacer el fondo transparente.
-        if (value == null || string.IsNullOrEmpty(value.ToString())) {
-            return Colors.Transparent;
-        }
-
-        // Si tiene contenido, establecer el color de fondo predeterminado
-        return (Color)Application.Current.Resources["SecondaryColor1"];
-    }
-
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
-    {
-        return null;
-    }
-}
-
-public class ContenidoToFontColorConverter : IValueConverter
-{
-    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
-    {
-        if (value == null || string.IsNullOrEmpty(value.ToString())) {
-            return (Color)Application.Current.Resources["FontColor1"];
-        }
-
-        return (Color)Application.Current.Resources["FontColor2"];
-    }
-
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
-    {
-        return null;
-    }
-}
-
-
 public partial class ResultsPage : ContentPage
 {
     private List<Advice> consejosDisponibles = new();

--- a/MejorAppTG1/Views/UserSelectPopup.xaml
+++ b/MejorAppTG1/Views/UserSelectPopup.xaml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<toolkit:Popup xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+               xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+               xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
+               xmlns:strings="clr-namespace:MejorAppTG1.Resources.Localization"
+               x:Class="MejorAppTG1.Views.UserSelectPopup"
+               Color="Transparent"
+               x:Name="UserSelectPopupRoot">
+    <Border Padding="0" HeightRequest="500"
+            WidthRequest="350"
+            Stroke="{StaticResource FontColor1}"
+            BackgroundColor="{StaticResource White}"
+            StrokeThickness="5">
+        <Border.StrokeShape>
+            <RoundRectangle CornerRadius="25"/>
+        </Border.StrokeShape>
+
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+            
+            <Label Text="{x:Static strings:Strings.str_LoginPage_LblSelectUser}"
+               FontSize="22"
+               Margin="0,20,0,5"
+               TextColor="{StaticResource FontColor1}"
+               HorizontalOptions="Center"
+               FontAttributes="Bold"
+               SemanticProperties.HeadingLevel="Level1"
+               SemanticProperties.Description="{x:Static strings:Strings.str_SemanticProperties_LoginPage_UsersPopup_Title}" />
+
+            <!-- Lista de usuarios -->
+            <CollectionView Grid.Row="1" x:Name="ClvUsuarios"
+                SelectionMode="Single"
+                VerticalOptions="FillAndExpand"
+                HorizontalOptions="FillAndExpand"
+                VerticalScrollBarVisibility="Always">
+
+                <CollectionView.ItemsLayout>
+                    <GridItemsLayout Orientation="Vertical" Span="2" />
+                </CollectionView.ItemsLayout>
+
+                <CollectionView.ItemTemplate>
+                    <DataTemplate>
+                        <Frame BorderColor="{StaticResource ButtonColor2}"
+                               CornerRadius="10"
+                               Margin="10"
+                               Padding="10"
+                               BackgroundColor="{StaticResource SecondaryColor3}"
+                               WidthRequest="140"
+                               HeightRequest="140"
+                               BindingContext="{Binding .}"
+                               BindingContextChanged="Frame_BindingContextChanged">
+                            <Frame.GestureRecognizers>
+                                <TapGestureRecognizer Tapped="TapGestureRecognizer_Tapped"/>
+                            </Frame.GestureRecognizers>
+                            
+                            <VerticalStackLayout Spacing="2"
+                                         VerticalOptions="Center">
+                                <Image Grid.Column="1"
+                                    HeightRequest="40"
+                                    WidthRequest="40"
+                                    Source="{Binding Imagen, Converter={StaticResource NullToDefaultImageConverter}}"
+                                    Aspect="AspectFill"
+                                    BackgroundColor="Transparent"
+                                    VerticalOptions="Center"
+                                    HorizontalOptions="Center"
+                                    SemanticProperties.Description="{x:Static strings:Strings.str_SemanticProperties_LoginPage_UsersPopup_Image}">
+                                    <Image.Clip>
+                                        <EllipseGeometry Center="20,20" RadiusX="20" RadiusY="20" />
+                                    </Image.Clip>
+                                </Image>
+
+                                <Label FontSize="20" x:Name="LblName"
+                               TextColor="{StaticResource FontColor4}"
+                               FontAttributes="Bold"
+                               Text="{Binding Nombre}" HorizontalTextAlignment="Center"
+                               SemanticProperties.Description="{x:Static strings:Strings.str_SemanticProperties_LoginPage_UsersPopup_Name}"/>
+
+                                <Label FontSize="15" x:Name="LblAge" BindingContextChanged="LblAge_BindingContextChanged"
+                               TextColor="{StaticResource FontColor5}"
+                               FontAttributes="Bold"
+                               Text="{Binding Edad}" HorizontalTextAlignment="Center"
+                               SemanticProperties.Description="{x:Static strings:Strings.str_SemanticProperties_LoginPage_UsersPopup_Age}"/>
+
+                                <Label FontSize="12" x:Name="LblGender" BindingContextChanged="LblGender_BindingContextChanged"
+                               TextColor="{StaticResource FontColor6}"
+                               FontAttributes="Bold"
+                               Text="{Binding Genero}" HorizontalTextAlignment="Center"
+                               SemanticProperties.Description="{x:Static strings:Strings.str_SemanticProperties_LoginPage_UsersPopup_Gender}"/>
+                            </VerticalStackLayout>
+                        </Frame>
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
+            </CollectionView>
+
+            <HorizontalStackLayout Margin="15" Spacing="10" HorizontalOptions="Center" Grid.Row="2">
+                <Button Text="{x:Static strings:Strings.str_ResultHistoryPage_BtnCancel}" x:Name="BtnCancel"
+                        BackgroundColor="{StaticResource ButtonColor2}"
+                        TextColor="{StaticResource FontColor2}"
+                        SemanticProperties.Description="{x:Static strings:Strings.str_SemanticProperties_LoginPage_SignUpPopup_BtnCancel}"
+                        Clicked="BtnCancel_Clicked"/>
+
+                <Button Text="{x:Static strings:Strings.str_LoginPage_BtnConfirm}" x:Name="BtnConfirm"
+                        BackgroundColor="{StaticResource ButtonColor1}"
+                        BorderColor="{StaticResource BorderColor1}"
+                        BorderWidth="2"
+                        CornerRadius="15"
+                        TextColor="{StaticResource FontColor2}"
+                        SemanticProperties.Description="{x:Static strings:Strings.str_SemanticProperties_LoginPage_BtnSignUp}"
+                        Clicked="BtnConfirm_Clicked"/>
+            </HorizontalStackLayout>
+
+        </Grid>
+    </Border>
+</toolkit:Popup>

--- a/MejorAppTG1/Views/UserSelectPopup.xaml.cs
+++ b/MejorAppTG1/Views/UserSelectPopup.xaml.cs
@@ -1,0 +1,112 @@
+using CommunityToolkit.Maui.Alerts;
+using CommunityToolkit.Maui.Views;
+using MejorAppTG1.Models;
+using MejorAppTG1.Resources.Localization;
+using System.Globalization;
+using CommunityToolkit.Maui.Core;
+using Application = Microsoft.Maui.Controls.Application;
+using Color = Microsoft.Maui.Graphics.Color;
+
+namespace MejorAppTG1.Views;
+
+public partial class UserSelectPopup : Popup
+{
+    private User? _selectedUser;
+    private Frame? _previousSelectedFrame;
+    public UserSelectPopup(List<User> usuarios)
+	{
+		InitializeComponent();
+		ClvUsuarios.ItemsSource = usuarios;
+    }
+
+    private void LblAge_BindingContextChanged(object sender, EventArgs e)
+    {
+        var edadLabel = sender as Label;
+        var user = (User)edadLabel.BindingContext;
+        if (user != null) {
+            int edad = user.Edad;
+            string translatedAgeFormat = Strings.str_ResultHistoryPage_LblAge_Dyn;
+            string translatedAge = string.Format(translatedAgeFormat, edad);
+            edadLabel.Text = translatedAge;
+        }
+    }
+
+    private void LblGender_BindingContextChanged(object sender, EventArgs e)
+    {
+        var generoLabel = sender as Label;
+        var user = (User)generoLabel.BindingContext;
+        if (user != null) {
+            string translatedGender = user.Genero switch {
+                "str_Genders_Man" => Strings.str_Genders_Man,
+                "str_Genders_Woman" => Strings.str_Genders_Woman,
+                "str_Genders_NB" => Strings.str_Genders_NB
+            };
+
+            generoLabel.Text = translatedGender;
+        }
+    }
+
+    private void Frame_BindingContextChanged(object sender, EventArgs e)
+    {
+        var currentFrame = sender as Frame;
+        if (currentFrame.BindingContext is User user) {
+            string translatedAgeFormat = Strings.str_ResultHistoryPage_LblAge_Dyn;
+            string translatedAge = string.Format(translatedAgeFormat, user.Edad);
+            string semanticDescription = string.Format(Strings.str_SemanticProperties_LoginPage_UsersPopup_SelectedUser, user.Nombre, translatedAge, Strings.ResourceManager.GetString(user.Genero, CultureInfo.CurrentUICulture));
+            SemanticProperties.SetDescription(currentFrame, semanticDescription);
+        }
+    }
+
+    private void BtnCancel_Clicked(object sender, EventArgs e)
+    {
+        if (App.ButtonPressed) return;
+        App.ButtonPressed = true;
+        try {
+            Close(null);
+        } finally {
+            App.ButtonPressed = false;
+        }
+    }
+
+    private void BtnConfirm_Clicked(object sender, EventArgs e)
+    {
+        if (App.ButtonPressed) return;
+        App.ButtonPressed = true;
+        try {
+            if (_selectedUser == null) {
+                Toast.Make(Strings.str_UserSelectPopup_ChooseUserToast, ToastDuration.Short).Show();
+            }
+            else {
+                Close(_selectedUser);
+            }
+        } finally {
+            App.ButtonPressed = false;
+        }
+    }
+
+    private void TapGestureRecognizer_Tapped(object sender, TappedEventArgs e)
+    {
+        var frame = sender as Frame;
+        if (frame?.BindingContext is User usuarioSeleccionado) {
+            if (_previousSelectedFrame != null) {
+                ResetFrameColor(_previousSelectedFrame);
+            }
+            App.AnimateFrameInOut(frame);
+            _selectedUser = usuarioSeleccionado;
+            UpdateSelectedFrameBorder(frame);
+            _previousSelectedFrame = frame;
+        }
+    }
+
+    private void ResetFrameColor(Frame frame)
+    {
+        frame.BorderColor = (Color)Application.Current.Resources["ButtonColor2"];
+        frame.BackgroundColor = (Color)Application.Current.Resources["SecondaryColor3"];
+    }
+
+    private void UpdateSelectedFrameBorder(Frame selectedFrame)
+    {
+        selectedFrame.BorderColor = (Color)Application.Current.Resources["HeaderColor1"];
+        selectedFrame.BackgroundColor = (Color)Application.Current.Resources["PrimaryColor"];
+    }
+}


### PR DESCRIPTION
- Todos los converters ahora son su propio .cs en Utils
- El popup de selección de usuario ahora es su propio .xaml
- Mejoras de selección de usuario: las tarjetas son más compactas y ahora caben dos por fila + no solo basta con pulsar en un usuario, sino que hay que confirmar la elección. Hay pistas visuales para indicar qué usuario está seleccionado actualmente.
- Eliminación de código inutilizado en LoginPage
- ResultHistoryPage renombrado a MyProfilePage para ser más representativo de su función